### PR TITLE
Fix python3.7 async issue - RuntimeError

### DIFF
--- a/executor/cli.py
+++ b/executor/cli.py
@@ -238,7 +238,7 @@ def run_command(arguments, timeout=None):
     """
     timer = Timer()
     logger.info("Running command: %s", quote(arguments))
-    with execute(*arguments, async=True) as command:
+    with execute(*arguments, asynchronous=True) as command:
         # Wait for the command to finish or exceed the given timeout.
         while command.is_running:
             if timeout and timer.elapsed_time > timeout:

--- a/executor/concurrent.py
+++ b/executor/concurrent.py
@@ -205,7 +205,7 @@ class CommandPool(PropertyManager):
         When a command is added to a command pool the following options are
         changed automatically:
 
-        - The :attr:`~executor.ExternalCommand.async` property is set to
+        - The :attr:`~executor.ExternalCommand.asynchronous` property is set to
           :data:`True`. If you want the commands to execute with a concurrency
           of one then you should set :attr:`concurrency` to one.
 
@@ -217,8 +217,8 @@ class CommandPool(PropertyManager):
           user tries to answer one of the prompts it will be impossible to tell
           which of the subprocesses will receive the user's reply).
         """
-        # Configure the command to run asynchronously.
-        command.async = True
+        # Configure the command to run asynchronoushronously.
+        command.asynchronous = True
         # Configure the command to run without a controlling terminal?
         if self.concurrency > 1:
             command.tty = False

--- a/executor/ssh/client.py
+++ b/executor/ssh/client.py
@@ -646,7 +646,7 @@ class SecureTunnel(RemoteCommand):
     """
 
     @mutable_property
-    def async(self):
+    def asynchronous(self):
         """Whether to enable asynchronous command execution (a boolean, defaults to :data:`True`)."""
         return True
 

--- a/executor/tcp.py
+++ b/executor/tcp.py
@@ -158,8 +158,8 @@ class EphemeralTCPServer(ExternalCommand, EphemeralPortAllocator):
     """
 
     @property
-    def async(self):
-        """Ephemeral TCP servers always set :attr:`.ExternalCommand.async` to :data:`True`."""
+    def asynchronous(self):
+        """Ephemeral TCP servers always set :attr:`.ExternalCommand.asynchronous` to :data:`True`."""
         return True
 
     def start(self, **options):

--- a/executor/tests.py
+++ b/executor/tests.py
@@ -204,10 +204,10 @@ class ExecutorTestCase(TestCase):
         self.assertEqual(e.returncode, 42)
         self.assertTrue('whatever' in e.error_message)
         # Make sure the CommandNotFound exception is raised consistently
-        # regardless of the values of the `shell' and `async' options.
-        for async in True, False:
+        # regardless of the values of the `shell' and `asynchronous' options.
+        for asynchronous in True, False:
             for shell in True, False:
-                cmd = ExternalCommand(MISSING_COMMAND, async=async, shell=shell)
+                cmd = ExternalCommand(MISSING_COMMAND, asynchronous=asynchronous, shell=shell)
                 self.assertRaises(CommandNotFound, cmd.wait)
                 assert cmd.returncode == COMMAND_NOT_FOUND_STATUS
 
@@ -350,7 +350,7 @@ class ExecutorTestCase(TestCase):
         fd, filename = tempfile.mkstemp(prefix='executor-', suffix='-streaming.txt')
         with open(filename, 'w') as handle:
             cmd = ExternalCommand('for ((i=0; i<25; i++)); do echo $i; sleep 0.1; done',
-                                  async=True, stdout_file=handle)
+                                  asynchronous=True, stdout_file=handle)
             cmd.start()
 
         def expect_some_output():
@@ -376,7 +376,7 @@ class ExecutorTestCase(TestCase):
                          'sys.stdout.write(sys.stdin.readline().upper())',
                          'sys.stdout.flush()',
                          'sys.stdout.write(sys.stdin.readline().upper())'),
-            async=True, buffered=False, capture=True, input=True
+            asynchronous=True, buffered=False, capture=True, input=True
         )
         with cmd:
             # Message the command.
@@ -521,9 +521,9 @@ class ExecutorTestCase(TestCase):
         cmd.wait()
         assert cmd.output == 'Also works fine'
 
-    def test_simple_async_cmd(self):
+    def test_simple_asynchronous_cmd(self):
         """Make sure commands can be executed asynchronously."""
-        cmd = ExternalCommand('sleep 4', async=True)
+        cmd = ExternalCommand('sleep 4', asynchronous=True)
         # Make sure we're starting from a sane state.
         assert not cmd.was_started
         assert not cmd.is_running
@@ -552,11 +552,11 @@ class ExecutorTestCase(TestCase):
         assert cmd.is_finished
         assert cmd.returncode == 0
 
-    def test_async_with_input(self):
+    def test_asynchronous_with_input(self):
         """Make sure asynchronous commands can be provided standard input."""
-        random_file = os.path.join(tempfile.gettempdir(), 'executor-%s-async-input-test' % os.getpid())
+        random_file = os.path.join(tempfile.gettempdir(), 'executor-%s-asynchronous-input-test' % os.getpid())
         random_value = str(random.random())
-        cmd = ExternalCommand('cat > %s' % quote(random_file), async=True, input=random_value)
+        cmd = ExternalCommand('cat > %s' % quote(random_file), asynchronous=True, input=random_value)
         try:
             cmd.start()
             cmd.wait()
@@ -568,10 +568,10 @@ class ExecutorTestCase(TestCase):
             if os.path.isfile(random_file):
                 os.unlink(random_file)
 
-    def test_async_with_output(self):
+    def test_asynchronous_with_output(self):
         """Make sure asynchronous command output can be captured."""
         random_value = str(random.random())
-        cmd = ExternalCommand('echo %s' % quote(random_value), async=True, capture=True)
+        cmd = ExternalCommand('echo %s' % quote(random_value), asynchronous=True, capture=True)
         cmd.start()
         cmd.wait()
         assert cmd.output == random_value
@@ -587,11 +587,11 @@ class ExecutorTestCase(TestCase):
 
     def test_event_callbacks(self):
         """Make sure the ``start_event`` and ``finish_event`` callbacks are actually invoked."""
-        for async in True, False:
+        for asynchronous in True, False:
             results = []
             cmd = ExternalCommand(
                 'sleep', '0.1',
-                async=async,
+                asynchronous=asynchronous,
                 start_event=lambda cmd: results.append(('started', time.time())),
                 finish_event=lambda cmd: results.append(('finished', time.time())),
             )
@@ -606,14 +606,14 @@ class ExecutorTestCase(TestCase):
     def test_repr(self):
         """Make sure that repr() on external commands gives sane output."""
         cmd = ExternalCommand('echo 42',
-                              async=True,
+                              asynchronous=True,
                               capture=True,
                               directory='/',
                               environment={'my_environment_variable': '42'})
         assert repr(cmd).startswith('ExternalCommand(')
         assert repr(cmd).endswith(')')
         assert 'echo 42' in repr(cmd)
-        assert 'async=True' in repr(cmd)
+        assert 'asynchronous=True' in repr(cmd)
         assert ('directory=%r' % '/') in repr(cmd)
         assert 'my_environment_variable' in repr(cmd)
         assert 'was_started=False' in repr(cmd)
@@ -707,19 +707,19 @@ class ExecutorTestCase(TestCase):
             # it exactly once. We expect this command to have succeeded when
             # the command pool is finished.
             script_1 = self.create_retry_script(directory, 2)
-            command_1 = ExternalCommand(script_1, async=True, retry=True, retry_limit=1)
+            command_1 = ExternalCommand(script_1, asynchronous=True, retry=True, retry_limit=1)
             pool.add(command_1)
             # Create a shell script that succeeds on the fourth run and retry
             # it up to two times. We expect this command to have failed when
             # the command pool is finished.
             script_2 = self.create_retry_script(directory, 4)
-            command_2 = ExternalCommand(script_2, async=True, retry=True, retry_limit=2)
+            command_2 = ExternalCommand(script_2, asynchronous=True, retry=True, retry_limit=2)
             pool.add(command_2)
             # Include a command without retries that succeeds.
-            command_3 = ExternalCommand('true', async=True, retry=False)
+            command_3 = ExternalCommand('true', asynchronous=True, retry=False)
             pool.add(command_3)
             # Include a command without retries that fails.
-            command_4 = ExternalCommand('false', async=True, retry=False)
+            command_4 = ExternalCommand('false', asynchronous=True, retry=False)
             pool.add(command_4)
             # Run the commands in the pool, expecting an `CommandPoolFailed'
             # exception because the second command will fail despite retrying


### PR DESCRIPTION
Python 3.7 does not allow the use of 'async' as
a parameter name or object attribute; update
occurrences to use a different name.

This is inline with PEP-492, where await and async
are keywords.