### PR TITLE
Replace deprecated `pipes` module with `shlex.quote`

### DIFF
--- a/executor/__init__.py
+++ b/executor/__init__.py
@@ -44,7 +44,6 @@ Classes and functions
 import errno
 import logging
 import os
-import pipes
 import pprint
 import shlex
 import signal
@@ -1986,7 +1985,7 @@ def quote(*args):
     """
     Quote a string or a sequence of strings to be used as command line argument(s).
 
-    This function is a simple wrapper around :func:`pipes.quote()` which
+    This function is a simple wrapper around :func:`shlex.quote()` which
     adds support for quoting sequences of strings (lists and tuples). For
     example the following calls are all equivalent::
 
@@ -2006,7 +2005,7 @@ def quote(*args):
     else:
         value = args[0]
         if not isinstance(value, (list, tuple)):
-            return pipes.quote(value)
+            return shlex.quote(value)
     return ' '.join(map(quote, value))
 
 


### PR DESCRIPTION
`pipes.quote` is undocumented. It is [mentioned](https://stackless.readthedocs.io/en/2.7-slp/library/pipes.html) in 2.7 docs as deprecated and exported as `shlex.quote`. Now whole `pipes` module is deprecated as of 3.11 and scheduled for removal in python 3.13.

Currently using executor results in a deprecation warning:

```
../../.venv/lib/python3.11/site-packages/executor/__init__.py:47
  /.venv/lib/python3.11/site-packages/executor/__init__.py:47: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
    import pipes
```